### PR TITLE
Improvements to install process and documentation, addition of `python` feature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If a change might need more discussion, please create a GitHub issue in this pro
 
 Before making a pull request, please be sure to run the script `bin/check.bash`. This will run our static analysis checks and unit tests, all of which must pass before a pull request will be accepted.
 
-Ensure that pull requests have meaningful titles. The title will be used in the changelog.
+Ensure that pull requests have meaningful titles. The title may be used in the changelog.
 
 ## Licensing and attribution
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "4.5.45", features = ["derive"] }
 humantime = "2.2.0"
 indicatif = "0.18.0"
 parquet = "56.0.0"
-pyo3 = { version = "0.25.1", features = ["anyhow"] }
+pyo3 = { version = "0.25.1", features = ["anyhow"], optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 strum = "0.27.2"
@@ -48,6 +48,7 @@ harness = false
 
 [features]
 multiharp = []
+python = ["dep:pyo3"]
 
 [lints.clippy]
 all = "deny"

--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
 
 Rust command-line interface and library, as well as Python bindings, for working with [time-to-digital converters (TDCs)](https://en.wikipedia.org/wiki/Time-to-digital_converter) such as the [PicoQuant MultiHarp 160](https://www.picoquant.com/products/category/tcspc-and-time-tagging-modules/multiharp-160).
 
+## Availability
+
+[Releases are available from crates.io](https://crates.io/crates/tdc_toolkit). Prebuilt binaries are not available at this time. See "Command-line interface," below, for installation and usage details.
+
 ## Supported devices
 
-The PicoQuant MultiHarp 150/160 series of devices are the only ones supported at this time. Stub implementations of this device are also available for testing and development.
+Only the PicoQuant MultiHarp 150/160 series of devices are supported at this time. Stub implementations of this device are also available for testing and development.
 
 ### PicoQuant MultiHarp
 
-This library was originally developed and tested using the [PicoQuant MultiHarp 160](https://www.picoquant.com/products/category/tcspc-and-time-tagging-modules/multiharp-160). Support is available on the `x86_64` only,
+This driver was developed and tested using the [PicoQuant MultiHarp 160](https://www.picoquant.com/products/category/tcspc-and-time-tagging-modules/multiharp-160) on Linux `x86_64`.
 
-Support depends on a proprietary driver library from [PicoQuant](https://www.picoquant.com/) that is only available for the `x86_64` architecture. Due to the proprietary library's license terms, we cannot distribute it with `tdc_toolkit`. Instead, it will be automatically downloaded when the `multiharp` feature is turned on.
+Support depends on a proprietary driver library from [PicoQuant](https://www.picoquant.com/) that is only available for `x86_64` Linux and Windows. Due to the proprietary library's license terms, we cannot distribute it with `tdc_toolkit`. When building on Linux, the library will be automatically downloaded and linked when the `multiharp` feature is turned on; Windows requires manual installation.
 
-When the `multiharp` feature is turned off, all MultiHarp support code remains present, but is only linked to a stub implementation of the real driver. This means it is still possible to develop for the MultiHarp on other architectures such as Apple Silicon/ARM before deploying to an `x86_64` device controller.
+When the `multiharp` feature is turned off, a stub implementation of the real driver is substituted. All other MultiHarp code remains present in the build. This allows MultiHarp-related development and testing on other architectures such as Apple Silicon/ARM.
 
 ## Command-line interface
 
@@ -20,13 +24,56 @@ When the `multiharp` feature is turned off, all MultiHarp support code remains p
 
 Nearly all users will want MultiHarp support via the `multiharp` feature; see "Supported Devices," above, for details.
 
+Issues and pull requests to expand the installation instructions are welcomed.
+
+#### x86_64 Linux
+
 ```bash
+# This will work on Debian and Ubuntu.
+# Users of other distributions should install similar packages.
+sudo apt install build-essential unzip
+
 cargo install --features multiharp tdc_toolkit
+```
+
+The installation will take quite a long time, as it must download a large package of files from PicoQuant in order to obtain the proprietary driver library.
+
+Users must also have appropriate permissions in order to access the MultiHarp device.
+
+First, create a group, here called `multiharp`, and add your user to it. Then, create a `udev` rule with the following content to give that group access to the device. Place the following in `/etc/udev/rules.d/50-multiharp.rules`; this file should be owned by `root:root` and have permissions `644`.
+
+```text
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0e0d", ATTRS{idProduct}=="0013", GROUP="multiharp", MODE="0660"
+```
+
+After creating the group and the `udev` rule, log out, log back in, and physically unplug and re-plug the MultiHarp device.
+
+It is also possible to forego `udev` configuration and instead run `tdc_toolkit` using `sudo`; this is not recommended.
+
+#### x86_64 Windows
+
+The installation process remains untested on Windows. However, this should work:
+
+* [Download the PicoQuant proprietary library version 3.1](https://www.picoquant.com/dl_software/MultiHarp150/MultiHarp150_160_V3_1.zip); newer versions are not yet supported.
+* Install the library at its default location: `C:\Program Files\PicoQuant\MultiHarp-MHLibv31`
+* Follow [Microsoft's instructions for getting started with Rust development](https://learn.microsoft.com/en-us/windows/dev-environment/rust/setup).
+* Run `cargo install --features multiharp tdc_toolkit`
+
+#### Non-x86_64 Linux, MacOS, and other Unix-like operating systems
+
+The `multiharp` feature can only be used on `x86_64` Linux and Windows. However, on other architectures and operating systems, the CLI can still be installed for evaluation.
+
+You will need to find your distribution's equivalent to the Debian package `build-essential`. On MacOS, [installing the Xcode command line tools](https://developer.apple.com/xcode/resources/) should be sufficient.
+
+```bash
+# On Debian or Ubuntu
+sudo apt install build-essential
+cargo install tdc_toolkit
 ```
 
 ### Usage
 
-Full usage information is available by running `tdc_toolkit help`.
+Run `tdc_toolkit help` for full usage information.
 
 #### info
 
@@ -53,6 +100,8 @@ Opens the device, configures it according to the provided configuration file, an
 
 To improve performance, long recordings will result in more than one Parquet file; at intervals of approximately 2 gigabytes, the current output file is closed and a new one opened. Most tools that support reading Parquet can treat a directory of many files as a single data source.
 
+The configuration file format is described in [the API documentation](https://docs.rs/tdc_toolkit/latest/tdc_toolkit/multiharp/device/struct.MH160DeviceConfig.html).
+
 ```bash
 $ tdc_toolkit record --device-config=sample_config/multiharp160.json --duration 2s
 [00:00:02] ████████████████████████████████████████ Recording complete
@@ -62,11 +111,13 @@ $ tdc_toolkit record --device-config=sample_config/multiharp160.json --duration 
 
 `tdc_toolkit` allows the construction of reusable, device-agnostic data processing pipelines. As an example, the MultiHarp's proprietary message format is first normalized into a common type before further processing occurs.
 
-More information is available in the API documentation on [docs.rs](https://docs.rs/).
+Consult the [the API documentation on docs.rs](https://docs.rs/tdc_toolkit/latest/tdc_toolkit/) for more information.
+
+When enabling the `multiharp` feature, be sure to note the prerequisite requirements listed in the CLI section above.
 
 ## Python bindings
 
-Basic typesafe Python bindings are available to control MultiHarp devices, and closely track the Rust API. They are documented in the `.pyi` files in `python/` and have not been extensively tested or released on PyPI.
+Basic typesafe Python bindings are available to control MultiHarp devices. They are documented in the `.pyi` files in `python/` and have not been extensively tested or released on PyPI. The easiest way to use them is as a [`uv` path dependency](https://docs.astral.sh/uv/concepts/projects/dependencies/#path). By default, the proprietary MultiHarp library is not used; the `features` key in the [`tool.maturin`] section of `pyproject.toml` must be modified to support it.
 
 At the moment, submodules such as `tdc_toolkit.multiharp` are not available as subpackages. This means that the following will not work:
 

--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,7 @@ fn main() {
                     lib_dir_path.display()
                 );
                 println!(
-                    "cargo::warning=Using the value of the MHLIB_LIB_DIR environment variable to find the Multiharp shared library."
+                    "cargo::warning=Using the value of the MHLIB_LIB_DIR environment variable to find the MultiHarp shared library."
                 );
             }
             Err(e) => match e {
@@ -50,14 +50,14 @@ fn main() {
 
                     if lib_dir_path.exists() {
                         println!(
-                            "cargo::warning=Using an existing copy of the Multiharp shared library in CARGO_MANIFEST_DIR {manifest_dir}"
+                            "cargo::warning=Using an existing copy of the MultiHarp shared library in CARGO_MANIFEST_DIR {manifest_dir}"
                         );
                     } else {
                         // Check to see if it was installed systemwide.
                         lib_dir_path = PathBuf::from("/usr/local/lib/mh150");
                         if lib_dir_path.exists() {
                             println!(
-                                "cargo::warning=Using the system installation of the Multiharp shared library."
+                                "cargo::warning=Using the system installation of the MultiHarp shared library."
                             );
                         } else {
                             // Download it ourselves.
@@ -72,10 +72,10 @@ fn main() {
                                 .join("MHLib_v3.1.0.0_64bit/library");
                             assert!(
                                 lib_dir_path.exists(),
-                                "Could not find a copy of the Multiharp library. Attempted to download the Multiharp library and failed. Don't know what to do. Exiting.",
+                                "Could not find a copy of the MultiHarp library. Attempted to download the MultiHarp library and failed. Don't know what to do. Exiting.",
                             );
                             println!(
-                                "cargo::warning=Downloaded a new copy of the Multiharp shared library and placed it in CARGO_MANIFEST_DIR {manifest_dir}."
+                                "cargo::warning=Downloaded a new copy of the MultiHarp shared library and placed it in CARGO_MANIFEST_DIR {manifest_dir}."
                             );
                         }
                     }
@@ -91,7 +91,7 @@ fn main() {
         lib_dir = lib_dir_path.to_string_lossy().into_owned();
         if lib_dir_path.join("mhlib.h").exists() {
             println!(
-                "cargo::warning=Found Multiharp header files in the same directory as the shared library. Using them."
+                "cargo::warning=Found MultiHarp header files in the same directory as the shared library. Using them."
             );
             include_dir.clone_from(&lib_dir);
         } else {
@@ -105,7 +105,7 @@ fn main() {
                 include_dir_path.display(),
             );
             println!(
-                "cargo::warning=Did not find Multiharp header files in the same directory as the shared library. Using a separate include directory."
+                "cargo::warning=Did not find MultiHarp header files in the same directory as the shared library. Using a separate include directory."
             );
             include_dir = include_dir_path.to_string_lossy().into_owned();
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ profile = "black"
 # `multiharp` feature or directly use the `maturin` command line with
 # `--features` instead of uv.
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "python"]
 module-name = "tdc_toolkit"
 python-source = "python"
 

--- a/src/bin/tdc_toolkit.rs
+++ b/src/bin/tdc_toolkit.rs
@@ -37,7 +37,7 @@ enum Command {
         #[arg(long, default_value_t = 0)]
         mh_device_index: u8,
 
-        /// MultiHarp-specific. Choose between implementations of the wrapper of PicoQuant's proprietary Multiharp control library.
+        /// MultiHarp-specific. Choose between implementations of the wrapper of PicoQuant's proprietary MultiHarp control library.
         #[arg(long, default_value_t = MhWrapperImplementation::default())]
         mh_wrapper_implementation: MhWrapperImplementation,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,4 +32,5 @@ pub mod multiharp;
 pub mod output;
 pub mod types;
 
+#[cfg(feature = "python")]
 mod python_api;

--- a/src/multiharp/device.rs
+++ b/src/multiharp/device.rs
@@ -15,7 +15,10 @@
 //! Some actions, such as [`MH160Device::get_device_info()`], do not require configuration.
 
 use anyhow::{Result, anyhow, bail};
+
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
@@ -26,7 +29,7 @@ use super::mhlib_wrapper::meta::{Edge, MhlibWrapper, Mode, RefSource};
 
 /// MultiHarp 160 device configuration.
 #[allow(clippy::unsafe_derive_deserialize)]
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct MH160DeviceConfig {
     /// Configuration for the sync channel. In the MultiHarp's internal representation, the sync channel is unnumbered. However, in TTTR T2 mode, the only mode `tdc_toolkit` currently supports, the sync channel essentially behaves as an extra channel, with no special properties.
@@ -43,7 +46,7 @@ pub struct MH160DeviceConfig {
 }
 
 #[allow(clippy::unsafe_derive_deserialize)]
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct MH160DeviceSyncChannelConfig {
     pub divider: i32,
@@ -53,7 +56,7 @@ pub struct MH160DeviceSyncChannelConfig {
 }
 
 #[allow(clippy::unsafe_derive_deserialize)]
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct MH160DeviceInputChannelConfig {
     /// The channel ID, corresponding to the channel ID numbers on the MultiHarp's interface panel. The ID must be greater than or equal to `1`. `0` is reserved for the sync channel.
@@ -66,7 +69,7 @@ pub struct MH160DeviceInputChannelConfig {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[serde(
     try_from = "Vec<MH160DeviceInputChannelConfig>",
     into = "Vec<MH160DeviceInputChannelConfig>"
@@ -115,7 +118,7 @@ impl From<MH160DeviceInputChannelConfigs> for Vec<MH160DeviceInputChannelConfig>
 ///
 /// Internally, the MultiHarp software counts channel IDs from zero and does not assign an ID to the sync channel. Lower-level APIs which require that internal representation use [`MH160InternalChannelId`](super::mhlib_wrapper::meta::MH160InternalChannelId).
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Copy, Clone, Debug)]
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[serde(try_from = "u8", into = "u8")]
 pub struct MH160ChannelId(u8);
 
@@ -144,7 +147,7 @@ impl From<MH160ChannelId> for u8 {
 }
 
 #[allow(clippy::unsafe_derive_deserialize)]
-#[pyclass(get_all, str)]
+#[cfg_attr(feature = "python", pyclass(get_all, str))]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct MH160DeviceInfo {
     // Amalgamation of device-related information collected from

--- a/src/multiharp/mhlib_wrapper/meta.rs
+++ b/src/multiharp/mhlib_wrapper/meta.rs
@@ -5,7 +5,10 @@
 //! The original constant names from `mhdefin.h` are preserved as comments.
 
 use anyhow::Result;
+
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use std::convert::Into;
 
@@ -15,7 +18,7 @@ pub const TTREADMAX: usize = 1_048_576;
 
 #[derive(Clone, Debug)]
 #[repr(i32)]
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub enum Mode {
     Hist = 0_i32, // MODE_HIST
     T2 = 2_i32,   // MODE_T2
@@ -24,7 +27,7 @@ pub enum Mode {
 
 #[derive(Clone, Debug)]
 #[repr(u32)]
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub enum RefSource {
     InternalClock = 0,                   // REFSRC_INTERNAL
     ExternalClock10MHz = 1,              // REFSRC_EXTERNAL_10MHZ
@@ -41,7 +44,7 @@ pub enum RefSource {
 #[allow(clippy::unsafe_derive_deserialize)]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 #[repr(i32)]
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub enum Edge {
     Falling = 0_i32, // EDGE_FALLING
     Rising = 1_i32,  // EDGE_RISING
@@ -49,7 +52,7 @@ pub enum Edge {
 
 #[derive(Clone)]
 #[repr(i32)]
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub enum MeasurementControl {
     SingleShotCtc = 0_i32,         // MEASCTRL_SINGLESHOT_CTC
     C1Gated = 1_i32,               // MEASCTRL_C1_GATED


### PR DESCRIPTION
* Separate the Python bindings out into a feature called `python` to simplify installing the CLI and reduce dependencies for non-Python library users
* Expand the documentation based on experience trying to `cargo install` the previous version on a clean virtual machine
* Use "MultiHarp" in prose everywhere, replace "Multiharp"